### PR TITLE
[MVC-21] (logging-mv-integration) standard format

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.5 (2017-10-17)
+------------------
+- Fix standard format
+
 0.1.4 (2017-10-09)
 ------------------
 - Multiple handlers fix

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Dependencies
 ============
 
 ``logging-mv-integrations`` module is built upon Python 3 and is build upon
-several custom modules that are held within .. _PyPI: https://pypi.python.org/pypi
+several custom modules that are held within PyPI: https://pypi.python.org/pypi
 
 .. code-block:: bash
     python3 -m pip install --upgrade -r requirements.txt
@@ -124,23 +124,18 @@ These packages provide support functionality but are not core
 to Multiverse. Thereby, test and documentation could be shared
 amongst the team.
 
-- .. _safe-cast: https://pypi.python.org/pypi/safe-cast
+- safe-cast: https://pypi.python.org/pypi/safe-cast
 
 
 Support Packages
 ----------------
 
-- .. _coloredlogs: https://pypi.python.org/pypi/coloredlogs
-- .. _pprintpp: https://pypi.python.org/pypi/pprintpp
-- .. _python-json-logger: https://pypi.python.org/pypi/python-json-logger
-- .. _Pygments: https://pypi.python.org/pypi/Pygments
-- .. _wheel: https://pypi.python.org/pypi/wheel
+- coloredlogs: https://pypi.python.org/pypi/coloredlogs
+- pprintpp: https://pypi.python.org/pypi/pprintpp
+- python-json-logger: https://pypi.python.org/pypi/python-json-logger
+- Pygments: https://pypi.python.org/pypi/Pygments
+- wheel: https://pypi.python.org/pypi/wheel
 
-
-Acknowledgements
-================
-
-.. include:: AUTHORS.rst
 
 Reporting Issues
 ================
@@ -150,7 +145,3 @@ We definitely want to hear your feedback.
 Report issues using the `Github Issue Tracker`:
 https://github.com/TuneLab/tune-mv-integration-python/issues
 
-HISTORY
-=======
-
-.. include:: HISTORY.rst

--- a/logging_mv_integrations/__init__.py
+++ b/logging_mv_integrations/__init__.py
@@ -4,8 +4,8 @@
 #  @namespace logging_mv_integrations
 
 __title__ = 'logging-mv-integrations'
-__version__ = '0.1.4'
-__build__ = 0x000104
+__version__ = '0.1.5'
+__build__ = 0x000105
 __version_info__ = tuple(__version__.split('.'))
 
 __author__ = 'jefft@tune.com'

--- a/logging_mv_integrations/tune_logging.py
+++ b/logging_mv_integrations/tune_logging.py
@@ -6,6 +6,7 @@
 import logging
 import logging.config
 from .logging_json_formatter import LoggingJsonFormatter
+from .logging_format import TuneLoggingFormat
 
 
 class CustomAdapter(logging.LoggerAdapter):
@@ -37,11 +38,14 @@ def get_logging_level(str_logging_level):
 
 def get_logger(logger_name, logger_version=None, logger_level=logging.INFO, logger_format=None):
 
-    formatter = LoggingJsonFormatter(
-        logger_name,
-        logger_version,
-        fmt='%(asctime)s %(levelname)s %(name)s %(version)s %(message)s'
-    )
+    if logger_format == TuneLoggingFormat.STANDARD:
+        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+    else:
+        formatter = LoggingJsonFormatter(
+            logger_name,
+            logger_version,
+            fmt='%(asctime)s %(levelname)s %(name)s %(version)s %(message)s'
+        )
 
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)


### PR DESCRIPTION
1. Use `logger_format` to decide which formatter to use
2. `README.rst` minor cleanup