### PR TITLE
Revert "[mvc-22] (requests-mv-integrations: Tests Fails) In method CustomAdapter.process clone kwargs"

### DIFF
--- a/logging_mv_integrations/tune_logging.py
+++ b/logging_mv_integrations/tune_logging.py
@@ -3,7 +3,6 @@
 #  @copyright 2016 TUNE, Inc. (http://www.tune.com)
 #  @namespace logging_mv_integrations
 
-import copy
 import logging
 import logging.config
 from .logging_json_formatter import LoggingJsonFormatter
@@ -13,13 +12,13 @@ from .logging_format import TuneLoggingFormat
 class CustomAdapter(logging.LoggerAdapter):
 
     def process(self, msg, kwargs):
-        kwargs_clone = copy.deepcopy(kwargs)
-        extra = kwargs_clone.get('extra')
+
+        extra = kwargs.get('extra')
         if extra:
-            kwargs_clone['extra'].update({'version': self.extra['version']})
+            kwargs['extra'].update({'version': self.extra['version']})
         else:
-            kwargs_clone['extra'] = {'version': self.extra['version']}
-        return msg, kwargs_clone
+            kwargs['extra'] = {'version': self.extra['version']}
+        return msg, kwargs
 
 
 def get_logging_level(str_logging_level):


### PR DESCRIPTION
Reverts TuneLab/logging-mv-integrations#23

@tulitune 

Reverted because it breaks running `requests-mv-integrations` example.

```
Traceback (most recent call last):
  File "examples/example_request.py", line 44, in <module>
    log.info("Completed", extra=vars(result))
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/logging/__init__.py", line 1634, in info
    self.log(INFO, msg, *args, **kwargs)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/logging/__init__.py", line 1671, in log
    msg, kwargs = self.process(msg, kwargs)
  File "/usr/local/lib/python3.6/site-packages/logging_mv_integrations/logger_adapter_custom.py", line 38, in process
    kwargs_clone = copy.deepcopy(kwargs)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 280, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 280, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/copy.py", line 169, in deepcopy
    rv = reductor(4)
TypeError: can't pickle zlib.Decompress objects
```